### PR TITLE
[fix] 채팅 시트 올라와 있는 상태에서도 dimLayer가 활성화되는 오류

### DIFF
--- a/ConDemo/TestViewController.swift
+++ b/ConDemo/TestViewController.swift
@@ -9,21 +9,10 @@ import UIKit
 
 class TestViewController: UIViewController {
     
-    private var didPresentSheet = false
-
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
         setupButtons()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        if !didPresentSheet {
-            presentAsBottomSheet(VoiceNoteViewController())
-            didPresentSheet = true
-        }
     }
 
     func setupButtons() {
@@ -78,34 +67,6 @@ class TestViewController: UIViewController {
             return
         }
         
-        didPresentSheet = false
         navigationController?.pushViewController(destinationVC, animated: true)
-    }
-    
-    func presentAsBottomSheet(_ viewController: UIViewController) {
-        // 시트 프레젠테이션 컨트롤러 구성
-        let customIdentifier = UISheetPresentationController.Detent.Identifier("custom20")
-        let customDetent = UISheetPresentationController.Detent.custom(identifier: customIdentifier) { context in
-            return 20 // 원하는 높이
-        }
-        
-        if let sheet = viewController.sheetPresentationController {
-            sheet.detents = [
-                customDetent,
-                .medium(), // 화면 중간 높이까지
-                .large()   // 전체 화면 높이
-            ]
-            
-            // 사용자가 시트를 끌어올릴 수 있도록 설정
-            sheet.prefersGrabberVisible = true
-            
-            // 시작 시 어떤 높이로 표시할지 설정
-            sheet.selectedDetentIdentifier = .some(customIdentifier)
-
-            // 드래그 중에 아래 뷰가 어두워지지 않도록 설정
-            sheet.largestUndimmedDetentIdentifier = .large
-        }
-        
-        present(viewController, animated: true)
     }
 }

--- a/ConDemo/ViewController/RecordingLandingViewController.swift
+++ b/ConDemo/ViewController/RecordingLandingViewController.swift
@@ -41,6 +41,7 @@ final class RecordingLandingViewController: UIViewController {
     private func setAddTargets() {
         recordingLandingView.startButton.addTarget(self, action: #selector(startButtonTapped),
                                                    for: .touchUpInside)
+        recordingLandingView.communityButton.addTarget(self, action: #selector(communityButtonTapped), for: .touchUpInside)
     }
 
     @objc
@@ -49,6 +50,11 @@ final class RecordingLandingViewController: UIViewController {
             self?.navigationController?.pushViewController(self!.recordingMainViewController,
                                                            animated: true)
         }
+    }
+    
+    @objc
+    private func communityButtonTapped() {
+        self.navigationController?.pushViewController(TestViewController(), animated: true)
     }
 }
 


### PR DESCRIPTION
## 📝 요약(Summary)

- bottomSheet가 활성화되어 있는 상태에서도 dimLayer가 깔리는 오류를 수정했습니다.
- 최초 화면 진입 시에만 bottomSheet가 활성화되는 오류를 수정했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

> 비밀입니다

## 💬 공유사항 to 리뷰어

- 바텀 시트가 최소 크기일 때에만 dimLayer를 활성화했습니다.
- 화면 재진입 시 바텀 시트가 올라오지 않는 오류가 있었는데, 화면이 disapeear될 때 바텀 시트 present 플래그가 false로 수정되지 않고 있었습니다. 
  -> viewWillDisappear에서 바텀 시트 플래그를 false로 설정했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
